### PR TITLE
Upgrade peerDeps compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "form validate"
   ],
   "peerDependencies": {
-    "react": "0.13 - 0.14"
+    "react": "0.13 - 15"
   },
   "dependencies": {
     "joi": "^6.10.1",


### PR DESCRIPTION
Everything works fine with React 15.x but npm flashes a big `UNMET PEER DEPENDENCY` warning everything I use npm. This change fixes that.
